### PR TITLE
feat: Scheduled Cleanup of Build Logs for all Deployments

### DIFF
--- a/src/backend/.env.sample
+++ b/src/backend/.env.sample
@@ -19,5 +19,5 @@ MAX_MEMORY_THRESHOLD=85
 MAX_RESTART_COUNT=5
 
 # Log Cleanup Configuration (all optional — sensible defaults are built-in)
-# LOG_CLEANUP_INTERVAL_MS=86400000  # 24 hours (default)
-# MAX_LOG_SIZE_BYTES=512000         # 500KB (default)
+LOG_CLEANUP_INTERVAL_MS=86400000  # 24 hours (default)
+MAX_LOG_SIZE_BYTES=512000         # 500KB (default)

--- a/src/backend/.env.sample
+++ b/src/backend/.env.sample
@@ -17,3 +17,7 @@ HEALTH_DEBUG=false
 MAX_CPU_THRESHOLD=90
 MAX_MEMORY_THRESHOLD=85
 MAX_RESTART_COUNT=5
+
+# Log Cleanup Configuration (all optional — sensible defaults are built-in)
+# LOG_CLEANUP_INTERVAL_MS=86400000  # 24 hours (default)
+# MAX_LOG_SIZE_BYTES=512000         # 500KB (default)

--- a/src/backend/db.ts
+++ b/src/backend/db.ts
@@ -138,4 +138,11 @@ async function getUserToken(userId: string) {
   return user?.authToken;
 }
 
-export { addMaps, checkUser, deleteMaps, getMaps, getDeploymentsByRepo, getUserToken };
+// Get all active subdomain names (used by log cleanup to detect orphaned files)
+async function getAllActiveSubdomains(): Promise<string[]> {
+  if (!contentMapsCollection) return [];
+  const docs = await contentMapsCollection.find({}, { projection: { subdomain: 1 } }).toArray();
+  return docs.map((doc: any) => doc.subdomain).filter(Boolean);
+}
+
+export { addMaps, checkUser, deleteMaps, getMaps, getDeploymentsByRepo, getUserToken, getAllActiveSubdomains };

--- a/src/backend/log-cleanup.ts
+++ b/src/backend/log-cleanup.ts
@@ -1,23 +1,15 @@
 import { Sentry } from "./dependencies.ts";
 import { getAllActiveSubdomains } from "./db.ts";
 
-// --- Configuration ---
-// Run cleanup once every 24 hours (configurable via env)
-const CLEANUP_INTERVAL_MS = parseInt(Deno.env.get("LOG_CLEANUP_INTERVAL_MS") || String(24 * 60 * 60 * 1000));
-// Maximum log file size to keep (500KB) — the API only serves the last 100KB,
-// so 5x headroom is plenty for SSH debugging while preventing unbounded growth
-const MAX_LOG_SIZE_BYTES = parseInt(Deno.env.get("MAX_LOG_SIZE_BYTES") || String(500 * 1024));
-// Paths where logs and status files live (matches container.sh / automate.sh)
+// --- Configs ---
+const CLEANUP_INTERVAL_MS = parseInt(Deno.env.get("LOG_CLEANUP_INTERVAL_MS") || String(24 * 60 * 60 * 1000)); // Default 24h
+const MAX_LOG_SIZE_BYTES = parseInt(Deno.env.get("MAX_LOG_SIZE_BYTES") || String(500 * 1024)); // Default 500KB
 const LOG_DIR = "/hostpipe/logs";
 const STATUS_DIR = "/hostpipe/status";
 
 let cleanupInterval: number | null = null;
 let isRunning = false;
 
-/**
- * Starts the log cleanup scheduler.
- * Safe to call multiple times — subsequent calls are no-ops.
- */
 export function startLogCleanup(): void {
   if (isRunning) {
     console.log("[Log Cleanup] Already running");
@@ -30,16 +22,11 @@ export function startLogCleanup(): void {
 
   isRunning = true;
 
-  // Run first cleanup after a short delay (don't block startup)
   setTimeout(() => runCleanup(), 10_000);
   cleanupInterval = setInterval(() => runCleanup(), CLEANUP_INTERVAL_MS);
 }
 
-/**
- * Core cleanup routine — runs both strategies:
- *   1. Truncate oversized log files for active subdomains
- *   2. Delete orphaned log/status files with no matching DB record
- */
+
 async function runCleanup(): Promise<void> {
   console.log("[Log Cleanup] Running cleanup cycle...");
 
@@ -47,10 +34,8 @@ async function runCleanup(): Promise<void> {
     const activeSubdomains = new Set(await getAllActiveSubdomains());
     console.log(`[Log Cleanup] Active subdomains in DB: ${activeSubdomains.size}`);
 
-    // --- Strategy 1: Truncate oversized log files ---
     await truncateOversizedLogs(activeSubdomains);
 
-    // --- Strategy 2: Remove orphaned files ---
     await removeOrphanedFiles(activeSubdomains);
 
     console.log("[Log Cleanup] Cleanup cycle complete.");
@@ -60,11 +45,7 @@ async function runCleanup(): Promise<void> {
   }
 }
 
-/**
- * Strategy 1: Truncate log files that exceed MAX_LOG_SIZE_BYTES.
- * Keeps the LAST MAX_LOG_SIZE_BYTES of each file (the most recent logs).
- * Only processes files that belong to active subdomains.
- */
+// Truncates oversized log files
 async function truncateOversizedLogs(activeSubdomains: Set<string>): Promise<void> {
   let truncatedCount = 0;
 
@@ -74,7 +55,6 @@ async function truncateOversizedLogs(activeSubdomains: Set<string>): Promise<voi
 
       const subdomain = entry.name.replace(/\.log$/, "");
 
-      // Only truncate logs for active subdomains — orphans are handled separately
       if (!activeSubdomains.has(subdomain)) continue;
 
       const filePath = `${LOG_DIR}/${entry.name}`;
@@ -85,7 +65,6 @@ async function truncateOversizedLogs(activeSubdomains: Set<string>): Promise<voi
         if (stat.size > MAX_LOG_SIZE_BYTES) {
           console.log(`[Log Cleanup] Truncating ${entry.name}: ${(stat.size / 1024).toFixed(0)}KB -> ${(MAX_LOG_SIZE_BYTES / 1024).toFixed(0)}KB`);
 
-          // Read the last MAX_LOG_SIZE_BYTES
           const file = await Deno.open(filePath, { read: true });
           const start = stat.size - MAX_LOG_SIZE_BYTES;
           await file.seek(start, Deno.SeekMode.Start);
@@ -98,18 +77,14 @@ async function truncateOversizedLogs(activeSubdomains: Set<string>): Promise<voi
           }
           file.close();
 
-          // Overwrite the file with only the tail content
           await Deno.writeFile(filePath, buffer.subarray(0, totalRead));
-
           truncatedCount++;
         }
       } catch (fileError) {
-        // Individual file errors shouldn't stop the whole cleanup
         console.error(`[Log Cleanup] Error processing ${entry.name}:`, fileError);
       }
     }
   } catch (dirError) {
-    // Log directory might not exist yet (fresh install) — that's fine
     if (!(dirError instanceof Deno.errors.NotFound)) {
       throw dirError;
     }
@@ -121,16 +96,11 @@ async function truncateOversizedLogs(activeSubdomains: Set<string>): Promise<voi
   }
 }
 
-/**
- * Strategy 2: Remove log and status files that don't belong to any active subdomain.
- * These are "orphans" — leftover from subdomains that were deleted but whose
- * files weren't cleaned up (e.g., server crashed during deletion).
- */
+// Removes orphaned log and status files
 async function removeOrphanedFiles(activeSubdomains: Set<string>): Promise<void> {
   let removedLogs = 0;
   let removedStatus = 0;
 
-  // Clean orphaned log files
   try {
     for await (const entry of Deno.readDir(LOG_DIR)) {
       if (!entry.isFile || !entry.name.endsWith(".log")) continue;
@@ -185,9 +155,7 @@ async function removeOrphanedFiles(activeSubdomains: Set<string>): Promise<void>
   }
 }
 
-/**
- * Returns current cleanup scheduler status (for debugging / health endpoint).
- */
+// Emit current cleanup scheduler stats
 export function getCleanupStatus(): {
   running: boolean;
   intervalMs: number;
@@ -204,9 +172,7 @@ export function getCleanupStatus(): {
   };
 }
 
-/**
- * Manually trigger a cleanup cycle (useful for admin/debugging).
- */
+// For manually triggering cleanup
 export async function triggerCleanup(): Promise<void> {
   console.log("[Log Cleanup] Manual cleanup triggered");
   await runCleanup();

--- a/src/backend/log-cleanup.ts
+++ b/src/backend/log-cleanup.ts
@@ -1,0 +1,213 @@
+import { Sentry } from "./dependencies.ts";
+import { getAllActiveSubdomains } from "./db.ts";
+
+// --- Configuration ---
+// Run cleanup once every 24 hours (configurable via env)
+const CLEANUP_INTERVAL_MS = parseInt(Deno.env.get("LOG_CLEANUP_INTERVAL_MS") || String(24 * 60 * 60 * 1000));
+// Maximum log file size to keep (500KB) — the API only serves the last 100KB,
+// so 5x headroom is plenty for SSH debugging while preventing unbounded growth
+const MAX_LOG_SIZE_BYTES = parseInt(Deno.env.get("MAX_LOG_SIZE_BYTES") || String(500 * 1024));
+// Paths where logs and status files live (matches container.sh / automate.sh)
+const LOG_DIR = "/hostpipe/logs";
+const STATUS_DIR = "/hostpipe/status";
+
+let cleanupInterval: number | null = null;
+let isRunning = false;
+
+/**
+ * Starts the log cleanup scheduler.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function startLogCleanup(): void {
+  if (isRunning) {
+    console.log("[Log Cleanup] Already running");
+    return;
+  }
+
+  console.log("[Log Cleanup] Starting scheduler...");
+  console.log(`[Log Cleanup] Interval: ${CLEANUP_INTERVAL_MS}ms (~${(CLEANUP_INTERVAL_MS / 3600000).toFixed(1)}h)`);
+  console.log(`[Log Cleanup] Max log size: ${(MAX_LOG_SIZE_BYTES / 1024).toFixed(0)}KB`);
+
+  isRunning = true;
+
+  // Run first cleanup after a short delay (don't block startup)
+  setTimeout(() => runCleanup(), 10_000);
+  cleanupInterval = setInterval(() => runCleanup(), CLEANUP_INTERVAL_MS);
+}
+
+/**
+ * Core cleanup routine — runs both strategies:
+ *   1. Truncate oversized log files for active subdomains
+ *   2. Delete orphaned log/status files with no matching DB record
+ */
+async function runCleanup(): Promise<void> {
+  console.log("[Log Cleanup] Running cleanup cycle...");
+
+  try {
+    const activeSubdomains = new Set(await getAllActiveSubdomains());
+    console.log(`[Log Cleanup] Active subdomains in DB: ${activeSubdomains.size}`);
+
+    // --- Strategy 1: Truncate oversized log files ---
+    await truncateOversizedLogs(activeSubdomains);
+
+    // --- Strategy 2: Remove orphaned files ---
+    await removeOrphanedFiles(activeSubdomains);
+
+    console.log("[Log Cleanup] Cleanup cycle complete.");
+  } catch (error) {
+    console.error("[Log Cleanup] Cleanup cycle failed:", error);
+    Sentry.captureException(error);
+  }
+}
+
+/**
+ * Strategy 1: Truncate log files that exceed MAX_LOG_SIZE_BYTES.
+ * Keeps the LAST MAX_LOG_SIZE_BYTES of each file (the most recent logs).
+ * Only processes files that belong to active subdomains.
+ */
+async function truncateOversizedLogs(activeSubdomains: Set<string>): Promise<void> {
+  let truncatedCount = 0;
+
+  try {
+    for await (const entry of Deno.readDir(LOG_DIR)) {
+      if (!entry.isFile || !entry.name.endsWith(".log")) continue;
+
+      const subdomain = entry.name.replace(/\.log$/, "");
+
+      // Only truncate logs for active subdomains — orphans are handled separately
+      if (!activeSubdomains.has(subdomain)) continue;
+
+      const filePath = `${LOG_DIR}/${entry.name}`;
+
+      try {
+        const stat = await Deno.stat(filePath);
+
+        if (stat.size > MAX_LOG_SIZE_BYTES) {
+          console.log(`[Log Cleanup] Truncating ${entry.name}: ${(stat.size / 1024).toFixed(0)}KB -> ${(MAX_LOG_SIZE_BYTES / 1024).toFixed(0)}KB`);
+
+          // Read the last MAX_LOG_SIZE_BYTES
+          const file = await Deno.open(filePath, { read: true });
+          const start = stat.size - MAX_LOG_SIZE_BYTES;
+          await file.seek(start, Deno.SeekMode.Start);
+          const buffer = new Uint8Array(MAX_LOG_SIZE_BYTES);
+          let totalRead = 0;
+          while (totalRead < MAX_LOG_SIZE_BYTES) {
+            const bytesRead = await file.read(buffer.subarray(totalRead));
+            if (bytesRead === null) break;
+            totalRead += bytesRead;
+          }
+          file.close();
+
+          // Overwrite the file with only the tail content
+          await Deno.writeFile(filePath, buffer.subarray(0, totalRead));
+
+          truncatedCount++;
+        }
+      } catch (fileError) {
+        // Individual file errors shouldn't stop the whole cleanup
+        console.error(`[Log Cleanup] Error processing ${entry.name}:`, fileError);
+      }
+    }
+  } catch (dirError) {
+    // Log directory might not exist yet (fresh install) — that's fine
+    if (!(dirError instanceof Deno.errors.NotFound)) {
+      throw dirError;
+    }
+    console.log("[Log Cleanup] Log directory not found, skipping truncation.");
+  }
+
+  if (truncatedCount > 0) {
+    console.log(`[Log Cleanup] Truncated ${truncatedCount} oversized log file(s).`);
+  }
+}
+
+/**
+ * Strategy 2: Remove log and status files that don't belong to any active subdomain.
+ * These are "orphans" — leftover from subdomains that were deleted but whose
+ * files weren't cleaned up (e.g., server crashed during deletion).
+ */
+async function removeOrphanedFiles(activeSubdomains: Set<string>): Promise<void> {
+  let removedLogs = 0;
+  let removedStatus = 0;
+
+  // Clean orphaned log files
+  try {
+    for await (const entry of Deno.readDir(LOG_DIR)) {
+      if (!entry.isFile || !entry.name.endsWith(".log")) continue;
+
+      const subdomain = entry.name.replace(/\.log$/, "");
+
+      if (!activeSubdomains.has(subdomain)) {
+        const filePath = `${LOG_DIR}/${entry.name}`;
+        console.log(`[Log Cleanup] Removing orphaned log: ${entry.name}`);
+        try {
+          await Deno.remove(filePath);
+          removedLogs++;
+        } catch (e) {
+          console.error(`[Log Cleanup] Failed to remove ${filePath}:`, e);
+        }
+      }
+    }
+  } catch (dirError) {
+    if (!(dirError instanceof Deno.errors.NotFound)) {
+      throw dirError;
+    }
+  }
+
+  // Clean orphaned status files
+  try {
+    for await (const entry of Deno.readDir(STATUS_DIR)) {
+      if (!entry.isFile || !entry.name.endsWith(".status")) continue;
+
+      const subdomain = entry.name.replace(/\.status$/, "");
+
+      if (!activeSubdomains.has(subdomain)) {
+        const filePath = `${STATUS_DIR}/${entry.name}`;
+        console.log(`[Log Cleanup] Removing orphaned status: ${entry.name}`);
+        try {
+          await Deno.remove(filePath);
+          removedStatus++;
+        } catch (e) {
+          console.error(`[Log Cleanup] Failed to remove ${filePath}:`, e);
+        }
+      }
+    }
+  } catch (dirError) {
+    if (!(dirError instanceof Deno.errors.NotFound)) {
+      throw dirError;
+    }
+  }
+
+  if (removedLogs > 0 || removedStatus > 0) {
+    const msg = `[Log Cleanup] Removed ${removedLogs} orphaned log(s) and ${removedStatus} orphaned status file(s).`;
+    console.log(msg);
+    Sentry.captureMessage(msg, "info");
+  }
+}
+
+/**
+ * Returns current cleanup scheduler status (for debugging / health endpoint).
+ */
+export function getCleanupStatus(): {
+  running: boolean;
+  intervalMs: number;
+  maxLogSizeBytes: number;
+  logDir: string;
+  statusDir: string;
+} {
+  return {
+    running: isRunning,
+    intervalMs: CLEANUP_INTERVAL_MS,
+    maxLogSizeBytes: MAX_LOG_SIZE_BYTES,
+    logDir: LOG_DIR,
+    statusDir: STATUS_DIR,
+  };
+}
+
+/**
+ * Manually trigger a cleanup cycle (useful for admin/debugging).
+ */
+export async function triggerCleanup(): Promise<void> {
+  console.log("[Log Cleanup] Manual cleanup triggered");
+  await runCleanup();
+}

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -23,6 +23,7 @@ import {
   triggerHealthCheckHandler,
 } from "./health-api.ts";
 import { startHealthMonitor } from "./health-monitor.ts";
+import { startLogCleanup } from "./log-cleanup.ts";
 
 const router = new Router();
 const app = new Application();
@@ -88,6 +89,9 @@ app.use(router.allowedMethods());
 
 // Start health monitoring service
 startHealthMonitor();
+
+// Start log cleanup scheduler
+startLogCleanup();
 
 app.listen({ port: PORT });
 console.log("Listening...");


### PR DESCRIPTION
# Feat: Scheduled Log Cleanup for Build Logs

## Problem

Build logs introduced in #63 are written via `tee -a` in `container.sh` and `automate.sh`, causing `{subdomain}.log` files to grow indefinitely across deployments and CI/CD redeployments.

This leads to:

- **Unbounded log growth** — Frequently redeployed subdomains can accumulate logs far larger than the 100KB ever served by the frontend.
- **Orphaned files** — Failed subdomain deletions can leave `.log` and `.status` files behind indefinitely.
    

## Solution

Added a scheduled cleanup module (`log-cleanup.ts`) that runs every 24 hours (following the existing `health-monitor.ts` scheduler pattern) and performs two cleanup strategies.

### 1. Log Truncation

For each active subdomain log in `/hostpipe/logs/`:

```text
if file_size > 500KB:
    keep only the last 500KB
```

Implementation:

1. Open the file for reading.
2. Seek to `file_size - 500KB`.
3. Read the last 500KB into memory.
4. Overwrite the file with that content.
    

This preserves recent deployment history while preventing unlimited growth. The existing `getLogs` API continues to serve the last 100KB via `readLastNBytes()`, while 500KB provides additional debugging context between cleanup cycles.

### 2. Orphan Cleanup

For every `.log` and `.status` file in `/hostpipe/logs/` and `/hostpipe/status/`:

```text
extract subdomain from filename
if subdomain not found in MongoDB:
    delete file
```

This removes artifacts left behind by incomplete deletions. Orphan removals are reported to Sentry for visibility and auditing.

## Scheduler Behavior

- First run: 10 seconds after server startup (`setTimeout`)
- Subsequent runs: every 24 hours (`setInterval`)
- Per-file error isolation via individual `try/catch`
- Missing directories are handled gracefully and skipped
    
## Checklist

- [x] Backward Compatibility is maintained
- [x] The code implementation has been tested on the staging server and all features are working as expected
- [x] Commits are Signed-off