### PR TITLE
Fix Display CPU in mCPU and add 2-decimal memory precision in cards.

### DIFF
--- a/src/backend/health-api.ts
+++ b/src/backend/health-api.ts
@@ -42,7 +42,7 @@ export async function getContainerHealth(ctx: Context): Promise<void> {
             status: c.status,
             cpuPercent: Math.round(c.cpuPercent * 100) / 100,
             memoryPercent: Math.round(c.memoryPercent * 100) / 100,
-            memoryUsageMB: Math.round(c.memoryUsage / (1024 * 1024)),
+            memoryUsageMB: Math.round((c.memoryUsage / (1024 * 1024)) * 100) / 100,
             restartCount: getRestartCount(c.name),
             stopCount: getStopCount(c.name),
             isHealthy: !isUnhealthy(c),
@@ -80,7 +80,7 @@ export async function getContainerMetrics(ctx: Context): Promise<void> {
         })),
         memory: history.memory.map(([ts, val]) => ({
             timestamp: new Date(ts).toISOString(),
-            valueMB: Math.round(val / (1024 * 1024)),
+            valueMB: Math.round((val / (1024 * 1024)) * 100) / 100,
         })),
     };
 }

--- a/src/backend/utils/container-health.ts
+++ b/src/backend/utils/container-health.ts
@@ -114,7 +114,7 @@ async function queryPrometheusRange(
 
 
 export async function getAllContainerStats(): Promise<ContainerStats[]> {
-    const cpuQuery = 'rate(container_cpu_usage_seconds_total{name=~".+"}[1m]) * 100';
+    const cpuQuery = 'irate(container_cpu_usage_seconds_total{name=~".+"}[1m]) * 100';
     const cpuResult = await queryPrometheus(cpuQuery);
     const memUsageQuery = 'container_memory_usage_bytes{name=~".+"}';
     const memLimitQuery = 'container_memory_max_usage_bytes{name=~".+"}';
@@ -181,7 +181,7 @@ export async function getContainerHistory(
     containerName: string,
     range: TimeRange
 ): Promise<{ cpu: [number, number][]; memory: [number, number][] }> {
-    const cpuQuery = `rate(container_cpu_usage_seconds_total{name="${containerName}"}[1m]) * 100`;
+    const cpuQuery = `irate(container_cpu_usage_seconds_total{name="${containerName}"}[1m]) * 100`;
     const memQuery = `container_memory_usage_bytes{name="${containerName}"}`;
 
     const [cpuResult, memResult] = await Promise.all([

--- a/src/frontend/src/components/ContainerHealth.vue
+++ b/src/frontend/src/components/ContainerHealth.vue
@@ -60,7 +60,7 @@
                   :class="getMetricClass(container.cpuPercent, 90)"
                 ></div>
               </div>
-              <span>{{ container.cpuPercent.toFixed(1) }}%</span>
+              <span>{{ (container.cpuPercent * 10).toFixed(2) }} mCPU</span>
             </div>
             
             <div class="metric">
@@ -72,7 +72,7 @@
                   :class="getMetricClass(container.memoryPercent, 85)"
                 ></div>
               </div>
-              <span>{{ container.memoryUsageMB }}MB</span>
+              <span>{{ container.memoryUsageMB.toFixed(2) }}MB</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Description
This PR improves metric visibility and precision on the Container Health Dashboard cards for lightweight/static user containers:
- **CPU Metrics**: Switched CPU metric unit from percentage to millicores (`mCPU` where `1% = 10 mCPU`) with 2 decimal places so low-utilization
containers display meaningful numbers instead of `0.00%`.
- **Prometheus Query**: Updated CPU Prometheus queries from `rate()` to `irate()` to capture instantaneous CPU bursts rather than diluting short activity
across a 60-second window.
- **Memory Precision**: Updated memory rounding in the backend and frontend to 2 decimal places (`MB`).

## Related Issue
Closes #69 

## Visual Demonstration (After)

https://github.com/user-attachments/assets/10367a2f-c278-412d-828e-695ea991836e

